### PR TITLE
Updated deployment.yaml example

### DIFF
--- a/docs/docs/introducing-atlas-operator/4-manage-atlas.md
+++ b/docs/docs/introducing-atlas-operator/4-manage-atlas.md
@@ -39,8 +39,8 @@ metadata:
 spec:
   projectRef:
     name: mern-k8s-project
-  clusterSpec:
-    name: "Cluster0"
+  deploymentSpec:
+    name: Cluster0
     providerSettings:
       instanceSizeName: M10
       providerName: AWS


### PR DESCRIPTION
Deploying with `clusterSpec` resulted in the below error, switched to `deploymentSpec` and started working from my end.

```
error validating "atlas/deployment.yaml": error validating data: ValidationError(AtlasDeployment.spec): unknown field "clusterSpec" in com.mongodb.atlas.v1.AtlasDeployment.spec
```